### PR TITLE
Radar hotfix

### DIFF
--- a/src/components/NewsPreview.tsx
+++ b/src/components/NewsPreview.tsx
@@ -36,10 +36,8 @@ export default function NewsPreview({ radarData, margin = defaultMargin }: NewsP
   const verticalScale = (d: number) => d * radius / Math.max(...radarData.map(y));
 
   const webs = genAngles(radarData.length);
-  const points = genPoints(radarData.length, radius);
+  const vertices = genPoints(radarData.length, radius);
   const polygonPoints = genPolygonPoints(radarData, (d) => verticalScale(d) ?? 0, y);
-  // Points on the outside of the polygon
-  const vertices = genPolygonPoints(radarData, (d) => d, y);
   const origin = new Point({ x: 0, y: 0 });
   
   return (
@@ -61,10 +59,10 @@ export default function NewsPreview({ radarData, margin = defaultMargin }: NewsP
             />
           ))}
           {[...new Array(radarData.length)].map((_, i) => (
-            <Line key={`radar-line-${i}`} from={origin} to={points[i]} stroke={silver} />
+            <Line key={`radar-line-${i}`} from={origin} to={vertices[i]} stroke={silver} />
           ))}
           <polygon points={polygonPoints.pointString} fill={peterRiver} fillOpacity={0.3} stroke={peterRiver} strokeWidth={1} />
-          {points.map((point, i) => (
+          {vertices.map((point, i) => (
             <React.Fragment key={`radar-point-${i}`}>
               <text key={`radar-point-text-${i}`} x={1.1*point.x} y={1.1*point.y} dx={-10} dy={-10} fontSize={12} fill={belizeHole}>{radarData[i].name}</text>
             </React.Fragment>

--- a/src/components/NewsPreview.tsx
+++ b/src/components/NewsPreview.tsx
@@ -38,6 +38,8 @@ export default function NewsPreview({ radarData, margin = defaultMargin }: NewsP
   const webs = genAngles(radarData.length);
   const points = genPoints(radarData.length, radius);
   const polygonPoints = genPolygonPoints(radarData, (d) => verticalScale(d) ?? 0, y);
+  // Points on the outside of the polygon
+  const vertices = genPolygonPoints(radarData, (d) => d, y);
   const origin = new Point({ x: 0, y: 0 });
   
   return (
@@ -62,13 +64,14 @@ export default function NewsPreview({ radarData, margin = defaultMargin }: NewsP
             <Line key={`radar-line-${i}`} from={origin} to={points[i]} stroke={silver} />
           ))}
           <polygon points={polygonPoints.pointString} fill={peterRiver} fillOpacity={0.3} stroke={peterRiver} strokeWidth={1} />
+          {points.map((point, i) => (
+            <React.Fragment key={`radar-point-${i}`}>
+              <text key={`radar-point-text-${i}`} x={1.1*point.x} y={1.1*point.y} dx={-10} dy={-10} fontSize={12} fill={belizeHole}>{radarData[i].name}</text>
+            </React.Fragment>
+          ))}
           {polygonPoints.points.map((point, i) => (
             <React.Fragment key={`radar-point-${i}`}>
               <circle key={`radar-point-${i}`} cx={point.x} cy={point.y} r={4} fill={belizeHole} />
-              <text key={`radar-point-text-${i}`} x={point.x} y={point.y} dx={-10} dy={-10} fontSize={10} fill={belizeHole}>
-                {/* For lack of screen real estate, only show name if it is sufficiently far away from other points. */}
-                {radarData[i].prominence > 0.05 && radarData[i].name}
-              </text>
             </React.Fragment>
           ))}
         </Group>

--- a/src/components/NewsPreview.tsx
+++ b/src/components/NewsPreview.tsx
@@ -31,13 +31,15 @@ export default function NewsPreview({ radarData, margin = defaultMargin }: NewsP
   const xMax = width - margin.left - margin.right;
   const yMax = height - margin.top - margin.bottom;
   const radius = Math.min(xMax, yMax) / 2;
+  const positionScaleFactor = 1.1;
 
   const radialScale = (d: number) => d * (Math.PI * 2) / 360;
   const verticalScale = (d: number) => d * radius / Math.max(...radarData.map(y));
 
   const webs = genAngles(radarData.length);
   const vertices = genPoints(radarData.length, radius);
-  const polygonPoints = genPolygonPoints(radarData, (d) => verticalScale(d) ?? 0, y);
+  const labelPositions = genPoints(radarData.length, (positionScaleFactor + 0.05) * radius, positionScaleFactor);
+  const nodePositions = genPolygonPoints(radarData, (d) => verticalScale(d) ?? 0, y);
   const origin = new Point({ x: 0, y: 0 });
   
   return (
@@ -61,13 +63,13 @@ export default function NewsPreview({ radarData, margin = defaultMargin }: NewsP
           {[...new Array(radarData.length)].map((_, i) => (
             <Line key={`radar-line-${i}`} from={origin} to={vertices[i]} stroke={silver} />
           ))}
-          <polygon points={polygonPoints.pointString} fill={peterRiver} fillOpacity={0.3} stroke={peterRiver} strokeWidth={1} />
-          {vertices.map((point, i) => (
+          <polygon points={nodePositions.pointString} fill={peterRiver} fillOpacity={0.3} stroke={peterRiver} strokeWidth={1} />
+          {labelPositions.map((point, i) => (
             <React.Fragment key={`radar-point-${i}`}>
-              <text key={`radar-point-text-${i}`} x={1.1*point.x} y={1.1*point.y} dx={-10} dy={-10} fontSize={12} fill={belizeHole}>{radarData[i].name}</text>
+              <text key={`radar-point-text-${i}`} x={point.x} y={point.y} dx={0} dy={0} fontSize={12} fill={belizeHole} textAnchor="middle">{radarData[i].name}</text>
             </React.Fragment>
           ))}
-          {polygonPoints.points.map((point, i) => (
+          {nodePositions.points.map((point, i) => (
             <React.Fragment key={`radar-point-${i}`}>
               <circle key={`radar-point-${i}`} cx={point.x} cy={point.y} r={4} fill={belizeHole} />
             </React.Fragment>

--- a/src/utils/radar.ts
+++ b/src/utils/radar.ts
@@ -12,11 +12,11 @@ export const genAngles = (length: number) =>
     angle: i * (360 / length) + (length % 2 === 0 ? 0 : 360 / length / 2),
   }));
 
-export const genPoints = (length: number, radius: number) => {
+export const genPoints = (length: number, radius: number, horizontalStretch: number = 1, verticalStretch: number = 1) => {
   const step = (Math.PI * 2) / length;
   return [...new Array(length)].map((_, i) => ({
-    x: radius * Math.sin(i * step),
-    y: radius * Math.cos(i * step),
+    x: horizontalStretch * radius * Math.sin(i * step),
+    y: verticalStretch * radius * Math.cos(i * step),
   }));
 };
 


### PR DESCRIPTION
Per the suggestion from demo day, the radar charts now feature all the labels for named entities, and they are on the outside of the figure, rather than immediately next to their corresponding nodes.